### PR TITLE
Simpler saving

### DIFF
--- a/docs/options.html
+++ b/docs/options.html
@@ -378,10 +378,10 @@ of the Ace editor.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-attribute">save</span>: <span class="hljs-function"><span class="hljs-params">(event)</span> -&gt;</span>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-attribute">save</span>:<span class="hljs-function"> -&gt;</span>
     <span class="hljs-keyword">return</span> <span class="hljs-keyword">unless</span> <span class="hljs-property">@hasModel</span>()
 
-    $button = $(event.currentTarget)
+    $button = $(<span class="hljs-string">'#save_button'</span>)
     code    = <span class="hljs-property">@options</span>.ace.getValue()
 
     $button.button(<span class="hljs-string">'loading'</span>).delay(<span class="hljs-number">500</span>)
@@ -825,6 +825,17 @@ snippets.</p>
     <span class="hljs-property">@ace</span>.setShowPrintMargin(<span class="hljs-literal">no</span>)
     <span class="hljs-property">@ace</span>.getSession().<span class="hljs-literal">on</span> <span class="hljs-string">'change'</span>,<span class="hljs-function"> =&gt;</span>
       <span class="hljs-property">@model</span>.trigger(<span class="hljs-string">'modified'</span>, <span class="hljs-property">@hasUnsavedChanges</span>(), <span class="hljs-property">@ace</span>.getValue()) <span class="hljs-keyword">if</span> <span class="hljs-property">@hasModel</span>()
+
+    <span class="hljs-property">@ace</span>.commands.addCommand({
+      <span class="hljs-attribute">name</span>: <span class="hljs-string">'save'</span>
+      <span class="hljs-attribute">bindKey</span>: {
+        <span class="hljs-attribute">mac</span>: <span class="hljs-string">'Command-S'</span>
+        <span class="hljs-attribute">win</span>: <span class="hljs-string">'Ctrl-S'</span>
+      }
+      <span class="hljs-attribute">readOnly</span>: <span class="hljs-literal">no</span>
+      <span class="hljs-attribute">exec</span>:<span class="hljs-function"> =&gt;</span>
+        <span class="hljs-property">@controls</span>.save()
+    })
 
     <span class="hljs-property">@settings</span> = <span class="hljs-keyword">new</span> EditorSettingsView({ <span class="hljs-attribute">model</span>: <span class="hljs-property">@options</span>.settings })
     <span class="hljs-property">@controls</span> = <span class="hljs-keyword">new</span> EditorControls({ <span class="hljs-property">@ace</span> })

--- a/docs/options.html
+++ b/docs/options.html
@@ -323,7 +323,7 @@ of the Ace editor.</p>
             
             <div class="content"><div class='highlight'><pre>  <span class="hljs-attribute">events</span>:
     <span class="hljs-string">'click #reset_button:not(:disabled)'</span>:  <span class="hljs-string">'reset'</span>
-    <span class="hljs-string">'click #update_button:not(:disabled)'</span>: <span class="hljs-string">'save'</span></pre></div></div>
+    <span class="hljs-string">'click #save_button:not(:disabled)'</span>: <span class="hljs-string">'save'</span></pre></div></div>
             
         </li>
         
@@ -409,7 +409,7 @@ of the Ace editor.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>  <span class="hljs-attribute">update</span>: <span class="hljs-function"><span class="hljs-params">(<span class="hljs-property">@model</span>)</span> -&gt;</span>
-    $buttons = <span class="hljs-property">@$</span>(<span class="hljs-string">'#reset_button, #update_button'</span>)</pre></div></div>
+    $buttons = <span class="hljs-property">@$</span>(<span class="hljs-string">'#reset_button, #save_button'</span>)</pre></div></div>
             
         </li>
         

--- a/src/_locales/en/messages.cson
+++ b/src/_locales/en/messages.cson
@@ -259,7 +259,7 @@ snippet_clone_header:
   description: 'Header for the clone snippet form modal dialog.'
 
 snippet_edit_button:
-  message: 'Update'
+  message: 'Save'
   description: 'Text for the submit button in the edit snippet modal dialog form.'
 
 snippet_edit_header:
@@ -290,10 +290,10 @@ top_button:
   message: 'Back to top'
   description: 'Text for the link in the footer that takes the user to the top of the page.'
 
-update_button:
-  message: 'Update'
-  description: 'Text for the Update button.'
+save_button:
+  message: 'Save'
+  description: 'Text for the Save button.'
 
-update_button_alt:
+save_button_alt:
   message: 'Saving...'
-  description: 'Alternative text for the Update button which is displayed after being clicked.'
+  description: 'Alternative text for the Save button which is displayed after being clicked.'

--- a/src/coffee/options.coffee
+++ b/src/coffee/options.coffee
@@ -61,7 +61,7 @@ EditorControls = Injector.View.extend {
   # Register DOM events for the editor controls
   events:
     'click #reset_button:not(:disabled)':  'reset'
-    'click #update_button:not(:disabled)': 'save'
+    'click #save_button:not(:disabled)': 'save'
 
   # Render the editor controls.
   render: ->
@@ -100,7 +100,7 @@ EditorControls = Injector.View.extend {
 
   # Update the state of the editor controls.
   update: (@model) ->
-    $buttons = @$('#reset_button, #update_button')
+    $buttons = @$('#reset_button, #save_button')
 
     # Ensure that specific buttons are only enabled when a snippet is selected.
     $buttons.prop('disabled', not @hasModel())

--- a/src/coffee/options.coffee
+++ b/src/coffee/options.coffee
@@ -81,10 +81,10 @@ EditorControls = Injector.View.extend {
     ace.gotoLine(0)
 
   # Save the contents of the Ace editor as the snippet code.
-  save: (event) ->
+  save: ->
     return unless @hasModel()
 
-    $button = $(event.currentTarget)
+    $button = $('#save_button')
     code    = @options.ace.getValue()
 
     $button.button('loading').delay(500)
@@ -264,6 +264,17 @@ EditorView = Injector.View.extend {
     @ace.setShowPrintMargin(no)
     @ace.getSession().on 'change', =>
       @model.trigger('modified', @hasUnsavedChanges(), @ace.getValue()) if @hasModel()
+
+    @ace.commands.addCommand({
+      name: 'save'
+      bindKey: {
+        mac: 'Command-S'
+        win: 'Ctrl-S'
+      }
+      readOnly: no
+      exec: =>
+        @controls.save()
+    })
 
     @settings = new EditorSettingsView({ model: @options.settings })
     @controls = new EditorControls({ @ace })

--- a/src/options.html
+++ b/src/options.html
@@ -222,7 +222,7 @@
 
                   <div id="editor_controls" class="pull-right">
                     <button id="reset_button" type="button" class="btn btn-warning" data-i18n-content="reset_button" disabled></button>
-                    <button id="update_button" type="button" class="btn btn-success" data-i18n-values=".innerHTML:update_button;data-loading-text:update_button_alt" disabled></button>
+                    <button id="save_button" type="button" class="btn btn-success" data-i18n-values=".innerHTML:save_button;data-loading-text:save_button_alt" disabled></button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Renamed the "Update" button to "Save" and added a keyboard shortcut to the editor for saving (`Ctrl+S` or `⌘+S` on OS X).
